### PR TITLE
Fix npm dependency conflict

### DIFF
--- a/wppconnect-server/package.json
+++ b/wppconnect-server/package.json
@@ -79,7 +79,7 @@
     "@types/qrcode": "^1.5.5",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/unzipper": "^0.10.11",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "commitizen": "^4.3.1",
     "conventional-changelog-cli": "^5.0.0",


### PR DESCRIPTION
## Summary
- update `@typescript-eslint/eslint-plugin` to `^8.34.1` to resolve dependency mismatch during Docker build

## Testing
- `npm install --production=false` in `wppconnect-server`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fca2b1708326bfc1f21ce3b12d53