### PR TITLE
Fix npm dependency conflict

### DIFF
--- a/wppconnect-server/package.json
+++ b/wppconnect-server/package.json
@@ -84,7 +84,7 @@
     "commitizen": "^4.3.1",
     "conventional-changelog-cli": "^5.0.0",
     "crypto-js": "^4.2.0",
-    "eslint": "^8.57.1",
+    "eslint": "^9.12.0",
     "eslint-config-love": "^119.0.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-import": "^2.31.0",


### PR DESCRIPTION
## Summary
- bump ESLint in `wppconnect-server` to satisfy peer dependency requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fe9d2ba48326a00103cddb35ecdd