### PR TITLE
Fix NPM install step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18
 WORKDIR /app
 COPY wppconnect-server/package.json ./wppconnect-server/package.json
-RUN cd wppconnect-server && npm install --production=false
+RUN cd wppconnect-server && npm install --production=false --legacy-peer-deps
 COPY wppconnect-server ./wppconnect-server
 WORKDIR /app/wppconnect-server
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- avoid dependency resolution errors during build by adding `--legacy-peer-deps`

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856001e7c108326a02af9b160a85795