### PR TITLE
Add Dockerfile to run project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache bash unzip
+
+COPY . .
+
+WORKDIR /app/WhaticketPlus-main
+
+RUN unzip -q whaticket.zip -d .
+
+WORKDIR /app/WhaticketPlus-main/whaticket/backend
+RUN npm install --production
+
+WORKDIR /app/WhaticketPlus-main/whaticket/frontend
+RUN npm install --production
+
+WORKDIR /app/WhaticketPlus-main
+RUN chmod +x start.sh
+
+CMD ["./start.sh"]


### PR DESCRIPTION
## Summary
- add a simple Dockerfile at repo root to run WhaticketPlus

## Testing
- `docker build -t test-image .` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560f2635048326bf2e208c2bad4aab