### PR TITLE
Fix deployment by resolving npm peer dependency conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /app/WhaticketPlus-main
 RUN unzip -q whaticket.zip -d .
 
 WORKDIR /app/WhaticketPlus-main/whaticket/backend
-RUN npm install --production
+RUN npm install --production --legacy-peer-deps
 
 WORKDIR /app/WhaticketPlus-main/whaticket/frontend
-RUN npm install --production
+RUN npm install --production --legacy-peer-deps
 
 WORKDIR /app/WhaticketPlus-main
 RUN chmod +x start.sh

--- a/WhaticketPlus-main/Dockerfile
+++ b/WhaticketPlus-main/Dockerfile
@@ -13,11 +13,11 @@ RUN unzip whaticket.zip -d .
 
 # Install backend dependencies
 WORKDIR /usr/src/app/whaticket/backend
-RUN npm install --production
+RUN npm install --production --legacy-peer-deps
 
 # Install frontend dependencies
 WORKDIR /usr/src/app/whaticket/frontend
-RUN npm install --production
+RUN npm install --production --legacy-peer-deps
 
 # Default environment variables
 ENV PORT=9003


### PR DESCRIPTION
## Summary
- prevent npm installation from failing due to peer dependency conflicts
- apply same fix in main Dockerfile and sub Dockerfile

## Testing
- `docker build -t testimage .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685610320b3c8326b1d2c0231b39fe63