### PR TITLE
Fix environment variable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,7 @@ docker run -p 8080:8080 \
     wapiapp
 ```
 
+All three variables are required when running the application. If any of them
+are missing the server will exit with an error message.
+
 The server exposes `/webhook` on port `8080` by default.

--- a/cmd/wapiapp/main.go
+++ b/cmd/wapiapp/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 
@@ -18,6 +19,15 @@ func getenv(key, def string) string {
 	return def
 }
 
+// mustGetenv reads an environment variable and exits if it is not set.
+func mustGetenv(key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		log.Fatalf("environment variable %s is required", key)
+	}
+	return val
+}
+
 func main() {
 	portStr := getenv("WEBHOOK_SERVER_PORT", "8080")
 	port, err := strconv.Atoi(portStr)
@@ -26,10 +36,10 @@ func main() {
 	}
 
 	cfg := &wapi.ClientConfig{
-		ApiAccessToken:    getenv("API_ACCESS_TOKEN", ""),
-		BusinessAccountId: getenv("BUSINESS_ACCOUNT_ID", ""),
+		ApiAccessToken:    mustGetenv("API_ACCESS_TOKEN"),
+		BusinessAccountId: mustGetenv("BUSINESS_ACCOUNT_ID"),
 		WebhookPath:       "/webhook",
-		WebhookSecret:     getenv("WEBHOOK_SECRET", ""),
+		WebhookSecret:     mustGetenv("WEBHOOK_SECRET"),
 		WebhookServerPort: port,
 	}
 


### PR DESCRIPTION
## Summary
- exit early when required environment variables are missing
- document required variables in README

## Testing
- `go build ./cmd/wapiapp`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6856208fc910832680d2662d6216cffd