### PR TITLE
Fix status caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ app.get('/', (_, res) => {
 });
 
 app.get('/status', (_, res) => {
+  res.set('Cache-Control', 'no-store');
   const status = {};
   for (const id of Object.keys(sessions)) {
     status[id] = !!(sessions[id].sock && sessions[id].sock.user);


### PR DESCRIPTION
## Summary
- disable caching on `/status` endpoint

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685695edb578832694197ec27c5111b5