### PR TITLE
Implement python dispatch and login system

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: sh -c 'node index.js & python server.py'

--- a/public/index.html
+++ b/public/index.html
@@ -758,6 +758,12 @@
         </div>
     </div>
 
+    <div id="progressBox" style="display:none;position:fixed;right:20px;bottom:70px;background:#222;color:#fff;padding:.75rem 1rem;border-radius:6px;">
+        <span id="progressText"></span>
+        <i class="fa-solid fa-spinner fa-spin" id="progressSpinner" style="margin-left:8px;"></i>
+    </div>
+    <div id="notification" style="display:none;position:fixed;right:20px;bottom:20px;background:#28a745;color:#fff;padding:.75rem 1rem;border-radius:6px;"></div>
+
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         // --- Cache (localStorage) Initialization ---
@@ -1098,29 +1104,6 @@
             });
         });
 
-        campaignForm.addEventListener('submit', (e) => {
-            e.preventDefault();
-            const selectedChipId = document.getElementById('chipSelector').value;
-            if (!selectedChipId) { alert('Por favor, conecte um chip primeiro.'); return; }
-
-            const messages = Array.from(variationsContainer.querySelectorAll('.message-input')).map(input => input.value).filter(val => val.trim() !== '');
-            if (messages.length === 0) { alert('Adicione pelo menos uma variação de mensagem.'); return; }
-            
-            const newCampaign = {
-                id: Date.now(),
-                name: document.getElementById('campaignName').value,
-                chipId: selectedChipId,
-                chipName: connections[selectedChipId].name || `Chip ${selectedChipId}`,
-                messages: messages,
-                contactsCount: document.getElementById('contacts').value.split('\n').filter(n => n.trim() !== '').length,
-                status: 'completed', // Simplified for demo
-            };
-            
-            campaigns.push(newCampaign);
-            saveState();
-            renderCampaigns();
-            closeModal(campaignModal);
-        });
         
         // Import Logic
         importContactsBtn.addEventListener('click', () => contactFileInput.click());
@@ -1169,6 +1152,50 @@
         });
 
         setInterval(updateStatuses, 10000);
+
+        const notifyEl = document.getElementById('notification');
+        const progressBox = document.getElementById('progressBox');
+        const progressText = document.getElementById('progressText');
+
+        function showNotification(msg) {
+            notifyEl.textContent = msg;
+            notifyEl.style.display = 'block';
+            setTimeout(() => notifyEl.style.display = 'none', 3000);
+        }
+
+        let progressTimer = null;
+        function pollProgress() {
+            fetch('/api/progress')
+                .then(r => r.json())
+                .then(data => {
+                    if (data.running) {
+                        progressText.textContent = `${data.sent}/${data.total}`;
+                        progressBox.style.display = 'block';
+                    } else {
+                        progressBox.style.display = 'none';
+                        clearInterval(progressTimer);
+                    }
+                });
+        }
+
+        campaignForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const selectedChipId = document.getElementById('chipSelector').value;
+            const messages = Array.from(variationsContainer.querySelectorAll('.message-input')).map(i => i.value).filter(v => v.trim() !== '');
+            const numbers = document.getElementById('contacts').value.split('\n').map(n => n.trim()).filter(Boolean);
+            fetch('/api/disparo', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ chip: selectedChipId, numbers: numbers, messages: messages })
+            }).then(r => {
+                if (r.ok) {
+                    showNotification('Disparo Iniciado');
+                    progressTimer = setInterval(pollProgress, 3000);
+                } else {
+                    alert('Erro ao iniciar disparo');
+                }
+            });
+        });
 
     });
     </script>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        body { display:flex; justify-content:center; align-items:center; height:100vh; background:#f5f5f5; font-family:Arial, sans-serif; }
+        .login-box { background:white; padding:2rem; border-radius:8px; box-shadow:0 4px 20px rgba(0,0,0,0.1); }
+        .login-box h2 { margin-bottom:1rem; }
+        .login-box input { width:100%; padding:0.5rem; margin-bottom:1rem; }
+        .login-box button { width:100%; padding:0.5rem; cursor:pointer; }
+    </style>
+</head>
+<body>
+    <div class="login-box">
+        <h2>Login</h2>
+        <form method="post" action="/login">
+            <input type="text" name="username" placeholder="Usuário" required>
+            <input type="password" name="password" placeholder="Senha" required>
+            <button type="submit">Entrar</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/server.py
+++ b/server.py
@@ -1,0 +1,92 @@
+import os
+import random
+import threading
+import time
+from flask import Flask, request, session, redirect, send_from_directory, jsonify
+import requests
+
+app = Flask(__name__)
+app.secret_key = os.getenv('SECRET_KEY', 'secret')
+LOGIN_USER = os.getenv('LOGIN', 'admin')
+LOGIN_PASS = os.getenv('SENHA', '1234')
+
+SEND_BASE = 'http://localhost:3000'
+progress = {'running': False, 'total': 0, 'sent': 0}
+
+
+def normalize(num: str):
+    digits = ''.join(filter(str.isdigit, num))
+    if digits.startswith('55') and len(digits) == 12:
+        return digits
+    if len(digits) == 11 and digits[2] == '9':
+        return '55' + digits[:2] + digits[3:]
+    return None
+
+
+def send_messages(numbers, messages, chip):
+    progress.update({'running': True, 'total': len(numbers), 'sent': 0})
+    for number in numbers:
+        if not progress['running']:
+            break
+        msg = random.choice(messages)
+        try:
+            requests.get(f"{SEND_BASE}/send/{chip}", params={'para': number, 'mensagem': msg})
+        except Exception as e:
+            print('Send error', e)
+        progress['sent'] += 1
+        time.sleep(random.randint(35, 120))
+    progress['running'] = False
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if request.form.get('username') == LOGIN_USER and request.form.get('password') == LOGIN_PASS:
+            session['user'] = LOGIN_USER
+            return redirect('/')
+        return 'Credenciais inválidas', 401
+    return send_from_directory('public', 'login.html')
+
+
+def login_required(func):
+    def wrapper(*args, **kwargs):
+        if 'user' not in session:
+            return redirect('/login')
+        return func(*args, **kwargs)
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+
+@app.route('/')
+@login_required
+def index():
+    return send_from_directory('public', 'index.html')
+
+
+@app.route('/public/<path:path>')
+def static_files(path):
+    return send_from_directory('public', path)
+
+
+@app.route('/api/disparo', methods=['POST'])
+@login_required
+def api_disparo():
+    data = request.json
+    nums = [normalize(n) for n in data.get('numbers', [])]
+    nums = [n for n in nums if n]
+    messages = data.get('messages', [])
+    chip = data.get('chip', '1')
+    if progress['running'] or not nums or not messages:
+        return jsonify({'status': 'error'}), 400
+    threading.Thread(target=send_messages, args=(nums, messages, chip), daemon=True).start()
+    return jsonify({'status': 'started'})
+
+
+@app.route('/api/progress')
+@login_required
+def api_progress():
+    return jsonify(progress)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add a Flask server with login and message dispatch logic
- add login page
- integrate progress display and dispatch calls in the frontend
- run both Node and Python servers via Procfile

## Testing
- `node --check index.js`
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_6856998c3dec832695bac26b22fb4cf3