### PR TITLE
Fix server and add Python sender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .session
 .wwebjs_auth
+*.pyc
+__pycache__/

--- a/sender.py
+++ b/sender.py
@@ -1,0 +1,39 @@
+import random
+import time
+import requests
+
+SEND_BASE = 'https://whatsapptest-stij.onrender.com'
+
+# Lista de contatos exemplo
+contatos = [
+    '5511999999999',
+]
+
+mensagens = [
+    'Ola, tudo bem?',
+    'Posso te apresentar uma oportunidade incrivel!',
+    'Se tiver interesse, me responde aqui \U0001f603',
+]
+
+def send_message(numero: str, mensagem: str, chip: str = '1'):
+    requests.get(
+        f"{SEND_BASE}/send/{chip}", params={"para": numero, "mensagem": mensagem}, timeout=30
+    )
+
+
+def main():
+    for contato in contatos:
+        mensagem = random.choice(mensagens)
+        try:
+            send_message(contato, mensagem)
+            print(f"\u2705 Mensagem enviada para {contato}")
+        except Exception as e:
+            print(f"\u274c Falha ao enviar para {contato}: {e}")
+        delay = random.randint(30, 60)
+        print(f"\u23f1 Aguardando {delay}s antes do proximo envio...")
+        time.sleep(delay)
+    print("\ud83d\ude80 Disparos finalizados.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix Python server imports
- use whatsapptest API base URL
- add single send endpoint
- add CLI sender example
- ignore Python bytecode

## Testing
- `python -m py_compile server.py sender.py`
- `npm install`
- `node index.js` *(fails: WebSocket Error)*

------
https://chatgpt.com/codex/tasks/task_e_68569d3ed4e88326a477e2266fb384f2