### PR TITLE
Add example /connect endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ python3 send_messages.py --chip 1 --mensagens mensagens.txt --contatos contatos.
 ```
 
 O envio é feito de forma humanizada com atrasos aleatórios entre 30 e 134 segundos e utiliza o endpoint `/send` do chip selecionado.
+
+## Novo endpoint /connect
+
+Um pequeno servidor Flask foi adicionado para demonstrar o endpoint `/connect`.
+Execute-o com:
+
+```bash
+pip install flask qrcode[pil] --user
+python3 connect_server.py
+```
+
+Acesse `http://localhost:8000/connect` em seu navegador. O primeiro acesso exibe
+um QR code. Ao escanear (ou acessar `?done=1`) a mensagem "Conectado com sucesso" 
+será exibida.

--- a/connect_server.py
+++ b/connect_server.py
@@ -1,0 +1,25 @@
+import base64
+import io
+from flask import Flask, request
+import qrcode
+
+app = Flask(__name__)
+connected = False
+
+@app.get('/connect')
+def connect():
+    global connected
+    if request.args.get('done') == '1':
+        connected = True
+    if connected:
+        return '<h1>Conectado com sucesso</h1>'
+    qr_data = request.url_root.rstrip('/') + '/connect?done=1'
+    img_io = io.BytesIO()
+    qrcode.make(qr_data).save(img_io, format='PNG')
+    img_io.seek(0)
+    b64 = base64.b64encode(img_io.getvalue()).decode()
+    html = f'<img src="data:image/png;base64,{b64}" alt="QR Code" />'
+    return html
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add `connect_server.py` to demonstrate a `/connect` endpoint
- document how to run the new server in the README

## Testing
- `python3 -m py_compile connect_server.py`
- `python3 -m py_compile send_messages.py`
- `python3 connect_server.py` *(fails: missing dependencies)*
- `pip install flask qrcode[pil]`
- `python3 connect_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68577a06fa5c83268bcfeaf63de97637