### PR TITLE
Add example /connect endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ python3 send_messages.py --chip 1 --mensagens mensagens.txt --contatos contatos.
 ```
 
 O envio é feito de forma humanizada com atrasos aleatórios entre 30 e 134 segundos e utiliza o endpoint `/send` do chip selecionado.
+
+## Novo endpoint /connect
+
+Um pequeno servidor Flask foi adicionado para demonstrar o endpoint `/connect`.
+Execute-o com:
+
+```bash
+pip install flask qrcode[pil] --user
+python3 connect_server.py
+```
+
+Acesse `http://localhost:8000/connect` em seu navegador. O primeiro acesso exibe
+um QR code. Ao escanear (ou acessar `?done=1`) a mensagem "Conectado com sucesso"
+será exibida.
+
+No frontend (`index.html`), um botão **Conectar Local** abre esse endpoint em um modal para facilitar o teste.

--- a/connect_server.py
+++ b/connect_server.py
@@ -1,0 +1,25 @@
+import base64
+import io
+from flask import Flask, request
+import qrcode
+
+app = Flask(__name__)
+connected = False
+
+@app.get('/connect')
+def connect():
+    global connected
+    if request.args.get('done') == '1':
+        connected = True
+    if connected:
+        return '<h1>Conectado com sucesso</h1>'
+    qr_data = request.url_root.rstrip('/') + '/connect?done=1'
+    img_io = io.BytesIO()
+    qrcode.make(qr_data).save(img_io, format='PNG')
+    img_io.seek(0)
+    b64 = base64.b64encode(img_io.getvalue()).decode()
+    html = f'<img src="data:image/png;base64,{b64}" alt="QR Code" />'
+    return html
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/index.html
+++ b/index.html
@@ -622,8 +622,9 @@
     
         <!-- Page: Conectar -->
         <section id="conectar" class="page active">
-            <div class="page-header">
+            <div class="page-header" style="display:flex;justify-content:space-between;align-items:center;">
                 <h2>Conectar Números</h2>
+                <button class="btn" id="openLocalConnectBtn"><i class="fa-solid fa-qrcode"></i> Conectar Local</button>
             </div>
             <div class="connections-grid">
                 <!-- Connection Cards will be populated by JS -->
@@ -752,7 +753,16 @@
             </div>
         </div>
     </div>
-    
+
+    <div id="localConnectModal" class="modal">
+        <div class="modal-content small">
+            <div class="modal-header"><h3>Conectar</h3><span class="close-btn" id="closeLocalConnect">&times;</span></div>
+            <div class="modal-body" style="text-align:center;">
+                <iframe id="localConnectFrame" src="/connect" style="width:100%;height:400px;border:none;"></iframe>
+            </div>
+        </div>
+    </div>
+
     <div id="importModal" class="modal">
         <div class="modal-content small">
             <div class="modal-header"><h3>Mapear Colunas</h3><span class="close-btn">&times;</span></div>
@@ -792,6 +802,9 @@
         const groupModal = document.getElementById('groupSelectorModal');
         const campaignModal = document.getElementById('campaignModal');
         const importModal = document.getElementById('importModal');
+        const openLocalConnectBtn = document.getElementById('openLocalConnectBtn');
+        const localConnectModal = document.getElementById('localConnectModal');
+        const localConnectFrame = document.getElementById('localConnectFrame');
         const selectGroupBtn = document.getElementById('selectGroupBtn');
 
         const createCampaignBtn = document.getElementById('createCampaignBtn');
@@ -986,6 +999,11 @@
             modal.addEventListener('click', (e) => {
                 if (e.target === modal) closeModal(modal);
             });
+        });
+
+        openLocalConnectBtn.addEventListener('click', () => {
+            localConnectFrame.src = '/connect';
+            openModal(localConnectModal);
         });
         
         // Gerador de Leads Logic


### PR DESCRIPTION
## Summary
- add `connect_server.py` to demonstrate a `/connect` endpoint
- document how to run the new server in the README
- integrate `/connect` with frontend via modal

## Testing
- `python3 -m py_compile connect_server.py`
- `python3 -m py_compile send_messages.py`
- `python3 connect_server.py` *(successfully started)*

------
https://chatgpt.com/codex/tasks/task_e_68577a06fa5c83268bcfeaf63de97637