### PR TITLE
Auto-connect chips at startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,9 +891,9 @@
             });
         };
 
-        const handleConnect = (instanceId) => {
+        const handleConnect = (instanceId, forceConnect = false) => {
             const baseUrl = BASE_URLS[instanceId];
-            if (connections[instanceId].connected) {
+            if (connections[instanceId].connected && !forceConnect) {
                 connections[instanceId].connected = false;
                 saveState();
                 renderConnectionCard(instanceId);
@@ -978,6 +978,7 @@
         Object.keys(connections).forEach(id => {
             renderConnectionCard(id);
             startStatusMonitor(id);
+            handleConnect(id, true);
         });
         renderCampaigns();
 


### PR DESCRIPTION
## Summary
- connect all chips automatically when loading the page
- refactor `handleConnect` to support forced connections

## Testing
- `python3 -m py_compile connect_server.py send_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_685790b4b1f483269df299f31766b25f