### PR TITLE
Use /connect for QR display

### DIFF
--- a/index.html
+++ b/index.html
@@ -913,12 +913,12 @@
                 fetch(baseUrl + '/connect', { method: 'POST', mode: 'no-cors' }).catch(() => {});
 
                 setTimeout(() => {
-                    qrPlaceholder.innerHTML = `<iframe src="${baseUrl}/qr"></iframe>`;
+                    qrPlaceholder.innerHTML = `<iframe src="${baseUrl}/connect"></iframe>`;
                     statusEl.textContent = 'Aguardando leitura...';
                     qrIntervals[instanceId] = setInterval(() => {
                         const iframe = qrPlaceholder.querySelector('iframe');
                         if (iframe) {
-                            iframe.src = `${baseUrl}/qr?${Date.now()}`;
+                            iframe.src = `${baseUrl}/connect?${Date.now()}`;
                         }
                     }, 1000);
                 }, 1000);


### PR DESCRIPTION
## Summary
- update connection status page to load `/connect` instead of `/qr`

## Testing
- `python3 -m py_compile connect_server.py send_messages.py`

------
https://chatgpt.com/codex/tasks/task_e_685791a010f08326aa2bfb35fba9645f