### PR TITLE
Enable CORS proxy for connection status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ um QR code. Ao escanear (ou acessar `?done=1`) a mensagem "Conectado com sucesso
 será exibida.
 
 No frontend (`index.html`), um botão **Conectar Local** abre esse endpoint em um modal para facilitar o teste.
+
+## Endpoint de proxy
+
+O servidor Flask também expõe `/proxy`, que recebe a URL desejada via `?url=` e
+retorna o conteúdo com cabeçalhos CORS liberados. Ele pode ser usado para
+contornar restrições de CORS durante o desenvolvimento.

--- a/connect_server.py
+++ b/connect_server.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import requests
 from flask import Flask, request, make_response
 import qrcode
 
@@ -37,6 +38,20 @@ def connect():
     b64 = base64.b64encode(img_io.getvalue()).decode()
     html = f'<img src="data:image/png;base64,{b64}" alt="QR Code" />'
     return html
+
+
+@app.route('/proxy')
+def proxy():
+    url = request.args.get('url')
+    if not url:
+        return 'Missing url parameter', 400
+    try:
+        r = requests.get(url, timeout=10)
+    except Exception as e:
+        return f'Erro ao buscar URL: {e}', 500
+    resp = make_response(r.text, r.status_code)
+    resp.headers['Content-Type'] = r.headers.get('Content-Type', 'text/plain')
+    return resp
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/index.html
+++ b/index.html
@@ -832,13 +832,15 @@
             navLinks.forEach(link => link.classList.toggle('active', link.dataset.target === targetId));
         };
 
+        const PROXY_BASE = 'http://localhost:8000/proxy?url=';
+
         const startStatusMonitor = (instanceId) => {
             if (statusIntervals[instanceId]) return;
             const baseUrl = BASE_URLS[instanceId];
             statusIntervals[instanceId] = setInterval(async () => {
                 let isConnected = false;
                 try {
-                    const r = await fetch(baseUrl + '/connect');
+                    const r = await fetch(PROXY_BASE + encodeURIComponent(baseUrl + '/connect'));
                     const txt = await r.text();
                     isConnected = txt.toLowerCase().includes('conectado com sucesso');
                 } catch (e) {


### PR DESCRIPTION
## Summary
- add a small proxy endpoint to `connect_server.py`
- document the new `/proxy` route in README
- use the proxy in `index.html` so the UI shows **Conectado** when the remote `/connect` page confirms the connection

## Testing
- `python3 -m py_compile connect_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685793b1931883269b3b96c756af5b78