### PR TITLE
Improve connection error handling

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -1,0 +1,3 @@
+Ao analisar o problema "Aguardando leitura" mesmo após conectar, foi verificado que o arquivo `index.html` realiza a checagem de conexão através do endpoint `/connect` utilizando o proxy local exposto por `connect_server.py`. Caso esse servidor não esteja rodando, a requisição falha e a interface permanece no estado de espera.
+
+Foi adicionado um tratamento de erro em `index.html` que exibe "Erro de conexão" se a consulta ao proxy falhar. O `README.md` foi atualizado ressaltando que o `connect_server.py` deve permanecer em execução para que o status de conexão seja atualizado corretamente.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ No frontend (`index.html`), um botão **Conectar Local** abre esse endpoint em u
 O servidor Flask também expõe `/proxy`, que recebe a URL desejada via `?url=` e
 retorna o conteúdo com cabeçalhos CORS liberados. Ele pode ser usado para
 contornar restrições de CORS durante o desenvolvimento.
+Mantenha esse servidor rodando enquanto utiliza a página `index.html`; caso
+contrário, o status de conexão ficará preso em "Aguardando leitura" mesmo após a
+leitura do QR Code.

--- a/index.html
+++ b/index.html
@@ -841,10 +841,15 @@
                 let isConnected = false;
                 try {
                     const r = await fetch(PROXY_BASE + encodeURIComponent(baseUrl + '/connect'));
+                    if (!r.ok) throw new Error('HTTP ' + r.status);
                     const txt = await r.text();
                     isConnected = txt.toLowerCase().includes('conectado com sucesso');
                 } catch (e) {
                     isConnected = false;
+                    const card = document.querySelector(`.connection-card[data-instance='${instanceId}']`);
+                    if (card) {
+                        card.querySelector('.status').textContent = 'Erro de conexão';
+                    }
                 }
                 if (connections[instanceId].connected !== isConnected) {
                     connections[instanceId].connected = isConnected;


### PR DESCRIPTION
## Summary
- show error text if status check fails
- clarify in README that connect_server.py must remain running
- capture reasoning in Memoria.txt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685796db9a3c8326966a2a425ee3b5cd