### PR TITLE
Fix chip selector

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -3,3 +3,4 @@ Ao analisar o problema "Aguardando leitura" mesmo após conectar, foi verificado
 Foi adicionado um tratamento de erro em `index.html` que exibe "Erro de conexão" se a consulta ao proxy falhar. O `README.md` foi atualizado ressaltando que o `connect_server.py` deve permanecer em execução para que o status de conexão seja atualizado corretamente.
 
 Foi removida a caixa do Gerador de Leads em index.html conforme solicitado.
+Agora o modal de criação de campanha exibe sempre as opções de Chip 1 a 3, mesmo quando nenhum está conectado.

--- a/index.html
+++ b/index.html
@@ -1133,15 +1133,10 @@
         createCampaignBtn.addEventListener('click', () => {
             const selector = document.getElementById('chipSelector');
             selector.innerHTML = '';
-            const connectedChips = Object.entries(connections).filter(([id, data]) => data.connected);
-            
-            if (connectedChips.length === 0) {
-                selector.innerHTML = '<option disabled>Nenhum chip conectado</option>';
-            } else {
-                connectedChips.forEach(([id, data]) => {
-                    selector.innerHTML += `<option value="${id}">${data.name || `Chip ${id}`}</option>`;
-                });
-            }
+
+            Object.entries(connections).forEach(([id, data]) => {
+                selector.innerHTML += `<option value="${id}">${data.name || `Chip ${id}`}</option>`;
+            });
             
             campaignForm.reset();
             variationsContainer.innerHTML = '';


### PR DESCRIPTION
## Summary
- show all chip options in campaign modal
- document this behavior in Memoria

## Testing
- `python3 -m py_compile send_messages.py connect_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6857dc0f313083268b07344f0d4718ab