### PR TITLE
Implement chip name confirmation

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -4,3 +4,4 @@ Foi adicionado um tratamento de erro em `index.html` que exibe "Erro de conexão
 
 Foi removida a caixa do Gerador de Leads em index.html conforme solicitado.
 Agora o modal de criação de campanha exibe sempre as opções de Chip 1 a 3, mesmo quando nenhum está conectado.
+Foi implementada a confirmação de nome do chip via tecla Enter. O README explica como nomear cada chip.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ ele não esteja acessível (por exemplo, ao hospedar o HTML em um serviço
 estático), o monitoramento de conexão exibirá **Erro de conexão (proxy
 offline?)**. Nesse caso, disponibilize o `connect_server.py` online e ajuste o
 valor de `PROXY_BASE` em `index.html` para apontar para o endereço correto.
+
+## Nomeando chips
+
+Em cada cartão de conexão é possível definir um nome para o chip. Digite o
+nome desejado no campo **Nome do Chip** e pressione **Enter** para confirmar.
+Esse nome aparecerá sempre que o chip estiver conectado e é salvo no cache do
+ navegador (localStorage).

--- a/index.html
+++ b/index.html
@@ -892,10 +892,18 @@
             `;
             
             card.querySelector('.connect-btn').addEventListener('click', () => handleConnect(instanceId));
-            card.querySelector('.instance-name').addEventListener('change', (e) => {
-                connections[instanceId].name = e.target.value;
+            const nameInput = card.querySelector('.instance-name');
+            const confirmName = () => {
+                connections[instanceId].name = nameInput.value;
                 saveState();
                 if(connections[instanceId].connected) renderConnectionCard(instanceId);
+            };
+            nameInput.addEventListener('change', confirmName);
+            nameInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    confirmName();
+                }
             });
         };
 


### PR DESCRIPTION
## Summary
- allow naming chips with enter confirmation on index.html
- document chip naming feature in README
- update Memoria with new entry

## Testing
- `python3 -m py_compile send_messages.py connect_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6857e8a2ceec8326ac2ef3a391c91c65