### PR TITLE
Improve lead export features

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -5,3 +5,4 @@ Foi adicionado um tratamento de erro em `index.html` que exibe "Erro de conexão
 Foi removida a caixa do Gerador de Leads em index.html conforme solicitado.
 Agora o modal de criação de campanha exibe sempre as opções de Chip 1 a 3, mesmo quando nenhum está conectado.
 Foi implementada a confirmação de nome do chip via tecla Enter. O README explica como nomear cada chip.
+Adicionada funcionalidade de exportação de contatos extraídos no Gerador de Leads. Agora é possível salvar em CSV ou XLSX usando o SheetJS. IDs de botões e script do CDN foram incluídos em index.html.

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     
     <!-- Font Awesome for Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
     
     <style>
         /* CSS Reset and Base Styles */
@@ -668,8 +669,8 @@
                         </table>
                     </div>
                     <div style="margin-top: 1.5rem; display: flex; gap: 1rem;">
-                        <button class="btn btn-secondary"><i class="fa-solid fa-file-csv"></i> Exportar CSV</button>
-                        <button class="btn btn-secondary"><i class="fa-solid fa-file-excel"></i> Exportar XLSX</button>
+                        <button class="btn btn-secondary" id="exportCsvBtn"><i class="fa-solid fa-file-csv"></i> Exportar CSV</button>
+                        <button class="btn btn-secondary" id="exportXlsxBtn"><i class="fa-solid fa-file-excel"></i> Exportar XLSX</button>
                     </div>
                 </div>
             </div>
@@ -1128,6 +1129,47 @@
                 cb.closest('tr').remove();
             });
             updateSelectionState();
+        });
+
+        function getContactsData() {
+            return Array.from(contactsListBody.querySelectorAll('tr')).map(tr => ({
+                Numero: tr.children[1].textContent.trim(),
+                Status: tr.children[2].textContent.trim()
+            }));
+        }
+
+        document.getElementById('exportCsvBtn').addEventListener('click', () => {
+            const data = getContactsData();
+            if (data.length === 0) { alert('Nenhum contato para exportar.'); return; }
+            let csv = 'Numero,Status\n';
+            data.forEach(d => { csv += `${d.Numero},${d.Status}\n`; });
+            const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'contatos.csv';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+
+        document.getElementById('exportXlsxBtn').addEventListener('click', () => {
+            const data = getContactsData();
+            if (data.length === 0) { alert('Nenhum contato para exportar.'); return; }
+            const ws = XLSX.utils.json_to_sheet(data);
+            const wb = XLSX.utils.book_new();
+            XLSX.utils.book_append_sheet(wb, ws, 'Contatos');
+            const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+            const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'contatos.xlsx';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
         });
 
 


### PR DESCRIPTION
## Summary
- add SheetJS for spreadsheet support
- allow exporting extracted leads to CSV or XLSX
- record update in project memory

## Testing
- `python -m py_compile connect_server.py send_messages.py`

------
https://chatgpt.com/codex/tasks/task_e_6857ed631c0c8326a06e2789a2aa428a